### PR TITLE
Don't use the strict comparison in the "elseif" parser.

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -135,9 +135,11 @@ var Twig = (function (Twig) {
                 return token;
             },
             parse: function (token, context, chain) {
-                var output = '';
+                var output = '',
+                    // Parse the expression
+                    result = Twig.expression.parse.apply(this, [token.stack, context]);
 
-                if (chain && Twig.expression.parse.apply(this, [token.stack, context]) === true) {
+                if (chain && result) {
                     chain = false;
                     // parse if output
                     output = Twig.parse.apply(this, [token.output, context]);


### PR DESCRIPTION
Make it identical to the "if" parser.

Fixes #149
