### PR TITLE
Fix the context issue in the "include" tag

### DIFF
--- a/src/twig.logic.js
+++ b/src/twig.logic.js
@@ -644,10 +644,7 @@ var Twig = (function (Twig) {
                     template;
 
                 if (!token.only) {
-                    for (i in context) {
-                        if (context.hasOwnProperty(i))
-                            innerContext[i] = context[i];
-                    }
+                    innerContext = Twig.ChildContext(context);
                 }
 
                 if (token.withStack !== undefined) {

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -294,6 +294,14 @@ describe("Twig.js Core ->", function() {
                 data: '{% extends "parent" %}{% set value = "test" %}{% block body %}{{ parent() }}{% endblock %}'
             }).render().should.equal("test");
         });
+
+        it("should use a correct context in the included template", function() {
+            twig({id: 'included', data: '{{ value }}\n{% set value = "inc" %}{{ value }}\n'});
+            twig({
+                allowInlineIncludes: true,
+                data: '{% set value = "test" %}{% for i in [0, 1] %}{% include "included" %}{% endfor %}{{ value }}'
+            }).render().should.equal("test\ninc\ntest\ninc\ntest");
+        });
     });
 });
 


### PR DESCRIPTION
{% include %} couldn't access the initial context when used in a for loop.
It also fixes a performance issue.